### PR TITLE
Group kube changes together

### DIFF
--- a/go.json
+++ b/go.json
@@ -22,6 +22,16 @@
             ]
         },
         {
+            "groupName": "K8s Modules",
+            "groupSlug": "k8s-go",
+            "matchDatasources": [
+                "go"
+            ],
+            "matchSourceUrlPrefixes": [
+                "k8s.io"
+            ]
+        },
+        {
             "groupName": "AWS SDK",
             "groupSlug": "aws-sdk-go",
             "matchDatasources": [


### PR DESCRIPTION
PR https://github.com/overmindtech/srcman/pull/135 has failed tests because the kube modules haven't all been updated and they need to remain in lockstep. This is my attempt at making rennovate treat them as one big group