### PR TITLE
Set max number of PRs and reduce amount of rebase activity on open PRs

### DIFF
--- a/js.json
+++ b/js.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "prConcurrentLimit": 2,
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": [


### PR DESCRIPTION
This limits the amount of open PRs to two at a time, reducing conflicts and rebase requirements.

This also changes renovates behaviour from rebasing on every push to main, to rebase only if there is a conflict. This should further reduce the number of "empty" CI runs for the update PRs