### PR TITLE
Avoid double-PRs on Fridays

### DIFF
--- a/schedule.json
+++ b/schedule.json
@@ -4,6 +4,6 @@
   "prConcurrentLimit": 0,
   "timezone": "Europe/London",
   "schedule": [
-    "before 4pm on friday"
+    "before 10am on friday"
   ]
 }


### PR DESCRIPTION
Sometimes renovate picks up a second update on friday afternoon, after the morning's updates have already been merged. This is not necessary, and - frankly - quite annoying.

Trimming the schedule to 10am will ensure that the PRs that get merged in the morning are the only ones that get opened.